### PR TITLE
Fixing exportAll

### DIFF
--- a/tasks/kvm_env.js
+++ b/tasks/kvm_env.js
@@ -12,25 +12,32 @@ module.exports = function(grunt) {
 		var passwd = apigee.from.passwd;
 		var filepath = grunt.config.get("exportEnvKVM.dest.data");
 		var done_count =0;
+		var done = this.async();
 		var envs_url = url + "/v1/organizations/" + org + "/environments";
+        
 		grunt.verbose.writeln(envs_url);
 		grunt.file.mkdir(filepath);
+        
 		request(envs_url, function (env_error, env_response, env_body) {
 			if (!env_error && env_response.statusCode == 200) {
 				grunt.verbose.writeln(env_body);
 			    var envs =  JSON.parse(env_body);
+                
 			    for (var j = 0; j < envs.length; j++) {
 			    	var env = envs[j];
 			    	var env_url = url + "/v1/organizations/" + org + "/environments/" + env + "/keyvaluemaps";
+                    
 			    	grunt.verbose.writeln("Env KVM URL: " + env_url);
+                    
 				    request(env_url, function (error, response, body) {
 						if (!error && response.statusCode == 200) {
-							//grunt.verbose.write(body);
+                            grunt.verbose.write(body);
 						    kvms =  JSON.parse(body);   						    
 						    for (var i = 0; i < kvms.length; i++) {
 						    	var env_kvm_url = this.env_url + "/" + kvms[i];	
 						    	grunt.verbose.writeln("KVM URL : " + env_kvm_url);
 						    	var env = this.env;
+                                
 						    	//Call kvm details
 								request(env_kvm_url, function (error, response, body) {
 									if (!error && response.statusCode == 200) {
@@ -43,27 +50,28 @@ module.exports = function(grunt) {
 									{
 										grunt.log.error(error);
 									}
-								}.bind( {env: env})).auth(userid, passwd, true);
+                                }.bind( {env: env})).auth(userid, passwd, true);
 						    	// End kvm details
-						    };
-						    
+						    };						    
 						} 
 						else
 						{
 							grunt.log.error(error);
 						}
-					}.bind( {env_url: env_url, env: env})).auth(userid, passwd, true);
+						done_count++;
+						if (done_count == envs.length)
+						{
+							grunt.log.ok('Exported ' + done_count + ' environment KVMs.');
+							done();
+						}
+                    }.bind( {env_url: env_url, env: env})).auth(userid, passwd, true);
 				}
 			}
 			else
 			{
 				grunt.log.error(error);
 			}
-
-
-
 		}).auth(userid, passwd, true);
-		var done = this.async();
 	});
 
 	grunt.registerMultiTask('importEnvKVM', 'Import all env-kvm to org ' + apigee.to.org + " [" + apigee.to.version + "]", function() {

--- a/tasks/kvm_proxy.js
+++ b/tasks/kvm_proxy.js
@@ -12,6 +12,7 @@ module.exports = function(grunt) {
 		var passwd = apigee.from.passwd;
 		var filepath = grunt.config.get("exportProxyKVM.dest.data");
 		var done_count =0;
+		var done = this.async();
 		var proxies_url = url + "/v1/organizations/" + org + "/apis";
 		grunt.verbose.writeln(proxies_url);
 		grunt.file.mkdir(filepath);
@@ -52,8 +53,13 @@ module.exports = function(grunt) {
 						{
 							grunt.log.error(error);
 						}
+						done_count++;
+						if (done_count == proxies.length)
+						{
+							grunt.log.ok('Exported ' + done_count + ' proxy KVMs.');
+							done();
+						}
 					}.bind( {proxy_url: proxy_url, proxy: proxy})).auth(userid, passwd, true);
-
 				}
 			}
 			else
@@ -61,7 +67,6 @@ module.exports = function(grunt) {
 				grunt.log.error(error);
 			}
 		}).auth(userid, passwd, true);
-		var done = this.async();
 	});
 
 

--- a/tasks/proxy.js
+++ b/tasks/proxy.js
@@ -13,12 +13,12 @@ module.exports = function(grunt) {
 		var filepath = grunt.config.get("exportProxies.dest.data");
 		var done_count =0;
 		var done = this.async();
+        // var done = this.async();
 		grunt.verbose.write("getting proxies..." + url);
 		url = url + "/v1/organizations/" + org + "/apis";
 
 		request(url, function (error, response, body) {
 			if (!error && response.statusCode == 200) {
-				//grunt.log.write(body);
 			    proxies =  JSON.parse(body);
 			   
 			    for (var i = 0; i < proxies.length; i++) {
@@ -30,34 +30,38 @@ module.exports = function(grunt) {
 						if (!error && response.statusCode == 200) {
 							grunt.verbose.write(body);
 						    var proxy_detail =  JSON.parse(body);
-						    var proxy_file = filepath + "/" + proxy_detail.name;
+                            // var proxy_file = filepath + "/" + proxy_detail.name;
 						    // gets max revision - May not be the deployed version
 						    var max_rev = proxy_detail.revision[proxy_detail.revision.length -1];
 
 						    var proxy_download_url = url + "/" + proxy_detail.name + "/revisions/" + max_rev + "?format=bundle";
-						    grunt.verbose.writeln ("Fetching proxy bundle  : " + proxy_download_url);
+						    grunt.verbose.writeln ("\nFetching proxy bundle  : " + proxy_download_url);
 
 						    request(proxy_download_url).auth(userid, passwd, true)
 							  .pipe(fs.createWriteStream(filepath + "/" + proxy_detail.name + '.zip'))
 							  .on('close', function () {
 							    //grunt.verbose.writeln('Proxy File written!');
-							  });
+							});
 						}
 						else
 						{
 							grunt.log.error(error);
 						}
+						done_count++;
+						if (done_count == proxies.length)
+						{
+							grunt.log.ok('Exported ' + done_count + ' proxies');
+							done();
+						}
 					}).auth(userid, passwd, true);
 			    	// End proxy details
-			    }; 
-			    
+			    }; 			    
 			} 
 			else
 			{
 				grunt.log.error(error);
 			}
 		}).auth(userid, passwd, true);
-
 	});
 
 	grunt.registerMultiTask('importProxies', 'Import all proxies to org ' + apigee.to.org + " [" + apigee.to.version + "]", function() {


### PR DESCRIPTION
In the exportAll task, which is a sequence of other tasks, the sequence was failing after exporting KVMs, proxies, and shared flows. Calling done() from within these seems to fix the problem.

- Add done() calls to exports for KVMs, proxies, and shared flows (shared flows were included in an earlier commit).

@vinit4u16 